### PR TITLE
fix live reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "browserify": "browserify js/main.jsx -t reactify -d -p [minifyify --map main.js.map --output dist/main.js.map] -o dist/main.js",
     "html": "cp index.html dist",
     "styles": "cp -r css dist && cp node_modules/bootstrap/dist/css/bootstrap.min.css dist/css && cp highlight/css/atelier-seaside.light.css dist/css",
-    "server": "browser-sync start --server dist --reload-delay 1000",
+    "server": "browser-sync start --files \"dist/main.css,dist/main.js\" --server dist --reload-delay 500",
     "build": "npm run clean && npm run html && npm run styles && npm run browserify",
     "watch": "npm run build && parallelshell \"npm run watchify\" \"npm run server\"",
     "watchify": "watchify js/main.jsx -t reactify --poll 100 -d -o dist/main.js"


### PR DESCRIPTION
`browser-sync` requires to know what files change monitor

```
{
   ...,
    "server": "browser-sync start --files \"dist/main.css,dist/main.js\" --server dist --reload-delay 500"
}
```
